### PR TITLE
Fix the incorrect assigning of "search_pattern" value to "_search_mode" variable

### DIFF
--- a/octoprint_SlicerEstimator/__init__.py
+++ b/octoprint_SlicerEstimator/__init__.py
@@ -142,7 +142,7 @@ class SlicerEstimatorPlugin(octoprint.plugin.StartupPlugin,
             self._psp = int(self._settings.get(["psp"]))
 
             self._search_mode = self._settings.get(["search_mode"])
-            self._search_mode = self._settings.get(["search_pattern"])
+            self._search_pattern = self._settings.get(["search_pattern"])
         else:
             self._set_slicer_settings(int(self._slicer_conf))
 

--- a/octoprint_SlicerEstimator/templates/SlicerEstimator_settings.jinja2
+++ b/octoprint_SlicerEstimator/templates/SlicerEstimator_settings.jinja2
@@ -44,8 +44,8 @@
                 <div class="help-block">{{ _('Select your slicer or custom setting which as to be configured in Custom-Tab.') }}
                     <p>
                     <ul>
-                        <li><b>Cura</b>: With Cura native no changes has to be applied to Cura. The overall print time is read out of a comment in the GCODE. For a correct estimation Octoprints percentage done is used as there is only the overall print time available.</li>
-                        <li><b>Cura M117</b>: M117 is read out of M117 commands added by Cura if the following Post-Processing actions are activated. This will update continouusly the remaining printing time</li> 
+                        <li><b>Cura</b>: With Cura native no changes have to be applied to Cura. The overall print time is read out of a comment in the GCODE. For a correct estimation Octoprints percentage done is used as there is only the overall print time available.</li>
+                        <li><b>Cura M117</b>: M117 is read out of M117 commands added by Cura if the following Post-Processing actions are activated. This will continuously update the remaining printing time</li> 
                         <li><b>Simply3D</b>: With Simplify3D no changes has to be applied to Simplify3D. The overall print time is read out of a comment in the GCODE. For a correct estimation Octoprints percentage done is used as there is only the overall print time available.</li>
                         <li><b>PrusaSlicer</b>: Remaining time is read out of M73 commands added by PrusaSlicer. This will update continuously the remaining print time.</li>
                     </ul>


### PR DESCRIPTION
I'm guessing this was a simple copy/paste error. But when rebooting OctoPrint this does break the plugin because the value of _search_mode is set to something that is neither "COMMENT" or "GCODE". That in turn causes the update function to do nothing.

Also fixed a little typo in one of the setting descriptions